### PR TITLE
standardised feature names

### DIFF
--- a/code/ML_inference_aux.py
+++ b/code/ML_inference_aux.py
@@ -1158,7 +1158,7 @@ def shapley_coeffs(data,decomp,target,features,mdl_type,is_TS=False,se_type='H3'
     df_rgr = df_rgr[all_cols]
     
     # regain original feature names
-    df_reg.index = [col_dict[i] for i in df_reg.index]
+    df_rgr.index = [col_dict[i] for i in df_rgr.index]
     
     # print to screen
     if verbose==True:


### PR DESCRIPTION
Certain feature names lead to a tokenization error with patsy. My suggestion thus is to standardise feature names and later on change the indices of the dataframe that is being output.
On another note, I find your idea brilliant.

Best
Roman